### PR TITLE
Add a link to getting started page

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,4 +31,4 @@ After executing the above command, you can use the following services and topics
 
 ## Installation and requirements
 
-Please see the [Getting stated](https://densorobot.github.io/docs/denso_cobotta_ros/getting_started.html) page.
+Please see the [Getting started](https://densorobot.github.io/docs/denso_cobotta_ros/getting_started.html) page.

--- a/README.md
+++ b/README.md
@@ -28,3 +28,7 @@ After executing the above command, you can use the following services and topics
   - /cobotta/position_button
   - /cobotta/robot_state
   - /cobotta/safe_state
+
+## Installation and requirements
+
+Please see the [Getting stated](https://densorobot.github.io/docs/denso_cobotta_ros/getting_started.html) page.


### PR DESCRIPTION
This PR adds a link to the getting started page of denso_cobotta_ros to the README.md.

Ref.: #12.